### PR TITLE
Remove unnecessary equal sign

### DIFF
--- a/R/d.ind.t.t.R
+++ b/R/d.ind.t.t.R
@@ -103,7 +103,7 @@ d.ind.t.t <- function (t, n1, n2, a = .05) {
                 "p" = p,
                 "estimate" = paste("$d_s$ = ", apa(d,2,T), ", ", (1-a)*100, "\\% CI [",
                                    apa(dlow,2,T), ", ", apa(dhigh,2,T), "]", sep = ""),
-                "statistic" = paste("$t$ = (", (n1-1+n2-1), ") = ",
+                "statistic" = paste("$t$(", (n1-1+n2-1), ") = ",
                                     apa(t,2,T), ", $p$ ", reportp, sep = "")
                 )
 


### PR DESCRIPTION
Previously results in `t = (df)`, but should be `t(df)`.